### PR TITLE
getProperty: return `this` when no arguments

### DIFF
--- a/MooTools-Core-1.6.0.js
+++ b/MooTools-Core-1.6.0.js
@@ -3490,6 +3490,9 @@ Element.implement({
 	},
 
 	getProperty: function(name){
+		if (!name) {
+			return this;
+		}
 		var getter = propertyGetters[name.toLowerCase()];
 		if (getter) return getter(this);
 		/* <ltIE9> */

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Core Modules
 
 Everything.
 
+Patched `Element.getProperty` to return the `Element` when called without arguments. This is a hack to fix a bug; see https://github.com/iFixit/mootools/pull/3 for details.
+
 
 More Modules
 -----


### PR DESCRIPTION
We encountered an issue (https://github.com/iFixit/ifixit/issues/42675) where Matomo Tag Manager expects a `get()` method to return an element if present. Since MooTools causes `get` on an Element to pass calls through to `getProperty`, we end up crashing because we call this method with no arguments. An easy hack is to return the element in that case, which doesn't require any other changes to the code, and probably does exactly what the Tag Manager expects.

This might look like it wouldn't be safe, because it changes MooTools behavior, but because it was incorrect to call `getProperty` without an argument (previously `name.toLowerCase()` would crash if `name` was undefined), there probably aren't a lot of places where this is happening, and those that exist are probably bugs.

## QA Notes
This is really tricky to QA ahead of time, because we don't currently have a way to reproduce the bug in dev. I'm also not concerned about breaking existing code with this, since it was probably already broken.

qa_req 0, because CI should be enough to confirm it doesn't break something important, and testing it in prod is the easiest way to see if it fixes the issue.

Connects #42675
